### PR TITLE
Fix recursion bug in findFilesByType

### DIFF
--- a/src/main/utils/FileSystemUtils.ts
+++ b/src/main/utils/FileSystemUtils.ts
@@ -87,9 +87,16 @@ function findFilesByType(source: string, ft: string, excludeDirs?: string[], exc
 
 	entries.forEach((entry) => {
 		const fullPath = path.join(source, entry);
-		if (fs.statSync(fullPath).isDirectory()) {
-			files.push(...findFilesByType(fullPath, ft, excludeDirs));
-		} else {
+                if (fs.statSync(fullPath).isDirectory()) {
+                        files.push(
+                                ...findFilesByType(
+                                        fullPath,
+                                        ft,
+                                        excludeDirs,
+                                        excludeFiles
+                                )
+                        );
+                } else {
 			const entryFt = path.extname(entry);
 			if (entryFt === ft) {
 				files.push(fullPath);


### PR DESCRIPTION
## Summary
- propagate excludeFiles through findFilesByType recursion

## Testing
- `pnpm lint` *(fails: ESLint couldn't find a config)*
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f459499d88323a31342e432d8460e