### PR TITLE
Fix mods data log typo

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -88,7 +88,7 @@ export default function App() {
 
 		// Listen for main context sending mods data
 		window.modManagerAPI.onMessage("send-mods-data", (data: ModsData) => {
-			log.info("Recieved mods data message: ", data);
+                        log.info("Received mods data message: ", data);
 			// Can't receive a Map, we receive an object, so convert it to a Map
 			setModsData(new Map(Object.entries(data)));
 		});


### PR DESCRIPTION
## Summary
- fix a typo in `src/renderer/App.tsx` for the mods data log message

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f46fbbcc8832396ce2417846cb519