### PR TITLE
Add unit test for formatDate

### DIFF
--- a/src/renderer/utils/formatDate.test.ts
+++ b/src/renderer/utils/formatDate.test.ts
@@ -1,0 +1,8 @@
+import { test, expect } from "vitest";
+import formatDate from "./formatDate";
+
+export function formatDateTest() {
+  expect(formatDate("4/1/2025, 12:34 PM")).toBe("04/01/2025");
+}
+
+test("formatDate should pad single digits", formatDateTest);


### PR DESCRIPTION
## Summary
- add `formatDate.test.ts` to validate `formatDate()`

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f46ee8a148323be24565235fa190a