### PR TITLE
Fix external link handling

### DIFF
--- a/src/renderer/components/mxb-mods/MXBModsView.tsx
+++ b/src/renderer/components/mxb-mods/MXBModsView.tsx
@@ -2,29 +2,39 @@
 import React, { useRef, useEffect } from "react";
 
 const MXBModsView: React.FC = () => {
-	const webviewRef = useRef<Electron.WebviewTag>(null);
+        const webviewRef = useRef<Electron.WebviewTag>(null);
 
-	useEffect(() => {
-		const wv = webviewRef.current!;
-		// intercept any link clicks that would open a popup
-		wv.addEventListener("new-window", (e: any) => {
-			e.preventDefault();
-			wv.loadURL(e.url); // load in the same webview
-		});
-		// intercept regular navigations if you’ve previously blocked them
-		wv.addEventListener("will-navigate", (e) => {
-			// if you had prevented external before, now just let it go:
-			// do nothing, and the webview will navigate
-		});
-	}, []);
+        useEffect(() => {
+                const wv = webviewRef.current!;
+                if (!wv) return;
+
+                const handleNewWindow = (e: any) => {
+                        console.log("new-window", e.url);
+                        e.preventDefault();
+                        wv.loadURL(e.url); // load in the same webview
+                };
+
+                const handleWillNavigate = (e: any) => {
+                        console.log("will-navigate", e.url);
+                };
+
+                wv.addEventListener("new-window", handleNewWindow);
+                wv.addEventListener("will-navigate", handleWillNavigate);
+
+                return () => {
+                        wv.removeEventListener("new-window", handleNewWindow);
+                        wv.removeEventListener("will-navigate", handleWillNavigate);
+                };
+        }, []);
 
 	return (
-		<webview
-			ref={webviewRef}
-			src="https://mxb-mods.com"
-			partition="persist:mods"
-			style={{ width: "100%", height: "100%" }}
-		/>
+                <webview
+                        ref={webviewRef}
+                        src="https://mxb-mods.com"
+                        allowpopups
+                        partition="persist:mods"
+                        style={{ width: "100%", height: "100%" }}
+                />
 	);
 };
 


### PR DESCRIPTION
## Summary
- rely on the renderer's `new-window` handler and deny new window creation in main

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f4bfdd6cc832388b497a7affa77ba